### PR TITLE
bug: rfk for uv installation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,9 +2,9 @@
 HALDA Solver - Distributed LLM Inference Optimization Library
 """
 
-from gurobi_solver import halda_solve
-from components.dataclasses import DeviceProfile, ModelProfile
-from components.gurobi_loader import load_device, load_model
+from .gurobi_solver import halda_solve
+from .components.dataclasses import DeviceProfile, ModelProfile
+from .components.gurobi_loader import load_device, load_model
 
 __all__ = [
     "halda_solve",

--- a/components/gurobi_loader.py
+++ b/components/gurobi_loader.py
@@ -13,8 +13,8 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from typing import Dict, List, Any, Optional, Tuple, Union
 from dataclasses import dataclass
-from components.dataclasses import DeviceProfile, ModelProfile, QuantPerf
-from gurobi_solver import halda_solve
+from .dataclasses import DeviceProfile, ModelProfile, QuantPerf
+from ..gurobi_solver import halda_solve
 
 
 def load_device_profile(device_path: str) -> DeviceProfile:

--- a/gurobi_solver.py
+++ b/gurobi_solver.py
@@ -19,8 +19,8 @@ import math
 import gurobipy as gp
 from gurobipy import GRB
 
-from components.dataclasses import DeviceProfile, ModelProfile, QuantPerf
-from components.plotter import plot_k_curve
+from .components.dataclasses import DeviceProfile, ModelProfile, QuantPerf
+from .components.plotter import plot_k_curve
 
 
 # --------------------------------------

--- a/main.py
+++ b/main.py
@@ -13,15 +13,15 @@ from typing import List, Optional
 # Add components to path
 sys.path.append(str(Path(__file__).parent / "components"))
 
-from components.gurobi_loader import (
+from .components.gurobi_loader import (
     load_devices_and_model,
     load_from_combined_json,
     load_from_profile_folder,
     load_device_profile,
     load_model_profile,
 )
-from components.dataclasses import DeviceProfile, ModelProfile
-from gurobi_solver import halda_solve
+from .components.dataclasses import DeviceProfile, ModelProfile
+from .gurobi_solver import halda_solve
 
 
 def print_device_summary(devices: List[DeviceProfile]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "dsolver"
 version = "0.1.0"
@@ -10,5 +14,6 @@ dependencies = [
   "scipy>=1.16.1",
 ]
 
-[tool.setuptools.packages.find]
-include = ["components*", "profiles*"]
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+sources = {"." = "dsolver"}

--- a/scipy_solver.py
+++ b/scipy_solver.py
@@ -10,7 +10,7 @@ import math
 import numpy as np
 from scipy.optimize import milp, LinearConstraint, Bounds
 
-from components.dataclasses import DeviceProfile, ModelProfile, QuantPerf
+from .components.dataclasses import DeviceProfile, ModelProfile, QuantPerf
 
 
 # -----------------------------


### PR DESCRIPTION
When used as a submodule with `file://` type of import, Uv was unable to see the imports from `dsolver`.
The changes here fix that.